### PR TITLE
Public APIs refactor with top-level dotenv constant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ packages
 docs/
 .env*
 !example/.env.example
+.packages
+doc/api

--- a/bin/dotenv.dart
+++ b/bin/dotenv.dart
@@ -1,16 +1,17 @@
 import 'dart:io';
 
 import 'package:args/args.dart';
-import 'package:dotenv/dotenv.dart' as dotenv;
+import 'package:dotenv/dotenv.dart';
 
 final _argPsr = new ArgParser()
   ..addFlag('help', abbr: 'h', negatable: false, help: 'Print this help text.')
   ..addOption('file',
       abbr: 'f',
       defaultsTo: '.env',
-      help: 'File to read.\nProvides environment variable definitions, one per line.');
+      help:
+          'File to read.\nProvides environment variable definitions, one per line.');
 
-/// Prints the [env] map.
+/// Prints the environment map.
 ///
 /// ## usage
 ///
@@ -21,7 +22,7 @@ void main(List<String> argv) {
   if (opts['help']) return _usage();
 
   dotenv.load(opts['file']);
-  _p(dotenv.env);
+  _p(dotenv);
 }
 
 void _usage() {

--- a/example/README.md
+++ b/example/README.md
@@ -1,9 +1,9 @@
-example
+Example
 =======
 
-Note consuming code must call `load` before accessing the `env` map.
+Note consuming code must call `dotenv.load()` before accessing variables.
 
-usage
+Usage
 -----
 
 From this directory, run
@@ -12,7 +12,8 @@ From this directory, run
 $ dart example.dart
 ```
 
-###### setup
+Setup
+-----
 
 Define variables in a `.env` file.
 

--- a/example/example.dart
+++ b/example/example.dart
@@ -1,22 +1,22 @@
 import 'dart:io';
 
-import 'package:dotenv/dotenv.dart' show load, clean, isEveryDefined, env;
+import 'package:dotenv/dotenv.dart' show dotenv;
 
 void main() {
-  load();
+  dotenv.load();
 
-  p('read all vars? ${isEveryDefined(['foo', 'baz'])}');
+  p('read all vars? ${dotenv.isEveryDefined(['foo', 'baz'])}');
 
-  p('value of foo is ${env['foo']}');
-  p('value of baz is ${env['baz']}');
-  p('your home directory is: ${env['HOME']}');
+  p('value of foo is ${dotenv['foo']}');
+  p('value of baz is ${dotenv['baz']}');
+  p('your home directory is: ${dotenv['HOME']}');
 
-  clean();
+  dotenv.clean();
 
   p('cleaned!');
-  p('env has key foo? ${env.containsKey('foo')}');
-  p('env has key baz? ${env.containsKey('baz')}');
-  p('your home directory is still: ${env['HOME']}');
+  p('env has key foo? ${dotenv.has('foo')}');
+  p('env has key baz? ${dotenv.has('baz')}');
+  p('your home directory is still: ${dotenv['HOME']}');
 }
 
 p(String msg) => stdout.writeln(msg);

--- a/lib/dotenv.dart
+++ b/lib/dotenv.dart
@@ -1,52 +1,135 @@
 /// Loads environment variables from a `.env` file.
 ///
-/// ## usage
+/// ## Usage
 ///
-/// Once you call [load], the top-level [env] map is available.
-/// You may wish to prefix the import.
+/// Use top-level [dotenv] constant to access environment variables.
 ///
-///     import 'package:dotenv/dotenv.dart' show load, env;
+/// In order to use variables defined in `.env` file one must first load it with
+/// `dotenv.load()`.
+///
+///     import 'package:dotenv/dotenv.dart';
 ///
 ///     void main() {
-///       load();
-///       var x = env['foo'];
-///       // ...
+///       dotenv.load();
+///       var x = dotenv['MY_VAR'];
 ///     }
+///
+/// Note that variables from [Platform.environment] will be loaded automatically.
+///
+/// > Variables defined in `.env` file will override variable values from
+/// > [Platform.environment] if names are the same.
 ///
 /// Verify required variables are present:
 ///
 ///     const _requiredEnvVars = const ['host', 'port'];
-///     bool get hasEnv => isEveryDefined(_requiredEnvVars);
+///     bool get hasEnv => dotenv.isEveryDefined(_requiredEnvVars);
+///
+/// The above code will check that each variable is set and it's value is not
+/// `null` and not empty.
 library dotenv;
 
 import 'dart:io';
+import 'package:logging/logging.dart';
 
 part 'src/parser.dart';
 
-var _env = new Map.from(Platform.environment);
+/// Logger for this library.
+///
+/// Can be accessed by client code via `Logger.root.children['dotenv']`.
+final Logger _logger = new Logger('dotenv');
 
-/// A copy of [Platform.environment](dart:io) including variables loaded at runtime from a file.
-Map<String, String> get env => _env;
+/// A copy of [Platform.environment](dart:io) including variables loaded at
+/// runtime from a file.
+const DotEnv dotenv = const DotEnv._();
 
-/// Overwrite [env] with a new writable copy of [Platform.environment](dart:io).
-Map clean() => _env = new Map.from(Platform.environment);
+/// Provides public interface for [dotenv] constant.
+class DotEnv {
+  static final Map _env = new Map.from(Platform.environment);
+
+  const DotEnv._();
+
+  /// Returns value of environment variable specified by [name]. If
+  /// variable does not exist returns `null`, so this method can not be used
+  /// to test for variable presence.
+  ///
+  /// To test if variable exists one must use [has] or [isEveryDefined].
+  String operator [](String name) => _env[name];
+
+  /// Returns `true` if environment variable exists. This will return `true`
+  /// even if variable value is set to `null` or is empty.
+  ///
+  /// This is equivalent to `Map.containsKey()`.
+  bool has(String name) => _env.containsKey(name);
+
+  /// Returns unmodifiable map with all environment variables.
+  Map toMap() => new Map.unmodifiable(_env);
+
+  /// Reads variables from [filename] and adds them to environment.
+  /// Logs a warning if [filename] does not exist.
+  void load([String filename = '.env', Parser parser = const Parser()]) {
+    var f = new File.fromUri(new Uri.file(filename));
+    var lines = _verify(f);
+    _env.addAll(parser.parse(lines));
+  }
+
+  List<String> _verify(File f) {
+    if (f.existsSync()) {
+      return f.readAsLinesSync();
+    } else {
+      _logger.warning('Load failed. File not found: ${f}');
+      return [];
+    }
+  }
+
+  /// True if all supplied variables have nonempty value; false otherwise.
+  /// Differs from [Map.containsKey] by excluding null values.
+  /// Note [dotenv.load] should be called first.
+  bool isEveryDefined(Iterable<String> vars) =>
+      vars.every((k) => _env[k] != null && _env[k].isNotEmpty);
+
+  /// Overwrite environment with a new copy of
+  /// [Platform.environment](dart:io).
+  void clean() {
+    _env.clear();
+    _env.addAll(Platform.environment);
+  }
+
+  @override
+  String toString() => _env.toString();
+}
+
+/// A copy of [Platform.environment](dart:io) including variables loaded
+/// at runtime from a file.
+///
+/// This returns __modifiable__ map so it is possible to make changes to
+/// environment directly via returned map object. One should not rely on this
+/// functionality since it's considered deprecated and will be removed in
+/// consequent releases.
+///
+/// **This function is deprecated, please use top-level [dotenv] constant.**
+@deprecated
+Map<String, String> get env => DotEnv._env;
+
+/// Overwrite environment with a new writable copy of
+/// [Platform.environment](dart:io).
+///
+/// **This function is deprecated, please use `dotenv.clean()` instead**
+@deprecated
+void clean() => dotenv.clean();
 
 /// True if all supplied variables have nonempty value; false otherwise.
 /// Differs from [containsKey](dart:core) by excluding null values.
-/// Note [load] should be called first.
-bool isEveryDefined(Iterable<String> vars) =>
-    vars.every((k) => _env[k] != null && _env[k].isNotEmpty);
+/// Note `dotenv.load()` should be called first.
+///
+/// **This function is deprecated, please use `dotenv.isEveryDefined()` instead**
+@deprecated
+bool isEveryDefined(Iterable<String> vars) => dotenv.isEveryDefined(vars);
 
-/// Read environment variables from [filename] and add them to [env].
+/// Read environment variables from [filename] and add them to environment.
 /// Logs to [stderr] if [filename] does not exist.
+///
+/// **This function is deprecated, please use `dotenv.load()` instead**
+@deprecated
 void load([String filename = '.env', Parser psr = const Parser()]) {
-  var f = new File.fromUri(new Uri.file(filename));
-  var lines = _verify(f);
-  _env.addAll(psr.parse(lines));
-}
-
-List<String> _verify(File f) {
-  if (f.existsSync()) return f.readAsLinesSync();
-  stderr.writeln('[dotenv] Load failed: file not found: $f');
-  return [];
+  dotenv.load(filename, psr);
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -33,6 +33,10 @@ packages:
     description: http_parser
     source: hosted
     version: "0.0.2+7"
+  logging:
+    description: logging
+    source: hosted
+    version: "0.11.2"
   matcher:
     description: matcher
     source: hosted
@@ -97,3 +101,4 @@ packages:
     description: yaml
     source: hosted
     version: "2.1.3"
+sdk: ">=1.9.0 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,6 +6,7 @@ homepage: https://github.com/mockturtl/dotenv
 environment:
   sdk: '>=1.8.0 <2.0.0'
 dependencies:
+  logging: "^0.11.2"
   args: ^0.13.0
 dev_dependencies:
   test: any

--- a/test/resources/extra.env
+++ b/test/resources/extra.env
@@ -1,0 +1,3 @@
+servlets=yes
+rats=yes
+horses=omgyes

--- a/test/resources/vars.env
+++ b/test/resources/vars.env
@@ -1,0 +1,4 @@
+x=1
+y=false
+z=foo
+empty=


### PR DESCRIPTION
This ended up being a bit more than I expected. Addresses #13 .
- Added top-level dotenv constant to avoid namespace collisions;
- Declared previous APIs deprecated; 
- Updated tests, documentation and examples.

Additionally:
- Implemented "integration" tests (loading env from files) ( #9 )
- Replaced stderr output with private library logger, to give users control over output of this library.
- New API does not provide write access to the env map for better encapsulation.

This is a big change, however existing APIs should still work (I added a test case for this).
If this gets merged it should probably go in `0.2.0` with deprecation notice for old APIs to be removed in `0.3.0`.

I can submit separate PR for removing old APIs.

Please let me know your thoughts!
