### PR TITLE
Allow equal signs (=) in values

### DIFF
--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -33,12 +33,12 @@ class Parser {
     var stripped = strip(line);
     if (!_isValid(stripped)) return {};
 
-    var sides = stripped.split('=');
-    var lhs = sides[0];
+    var splitIndex = stripped.indexOf('=');
+    var lhs = stripped.substring(0, splitIndex);
     var k = swallow(lhs);
     if (k.isEmpty) return {};
 
-    var rhs = sides[1].trim();
+    var rhs = stripped.substring(splitIndex + 1, stripped.length).trim();
     var quotChar = surroundingQuote(rhs);
     var v = unquote(rhs);
 

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -37,6 +37,7 @@ void main() {
         subj.interpolate_fallback);
     test('it handles \${surrounding braces} on vars', subj.interpolate_curlies);
 
+    test('it handles equal signs in values', subj.parseOne_equals);
     test('it knows quoted # is not a comment', subj.parseOne_pound);
     test('it handles quotes in a comment',
         subj.parseOne_commentQuote_terminalChar);
@@ -75,6 +76,16 @@ class ParserTest {
 
     expect(double['foo'], equals('ab#c'));
     expect(single['foo'], equals('ab#c'));
+  }
+
+  void parseOne_equals() {
+    var none = _psr.parseOne('foo=bar=qux');
+    var sing = _psr.parseOne("foo='bar=qux'");
+    var doub = _psr.parseOne('foo="bar=qux"');
+
+    expect(none['foo'], equals('bar=qux'));
+    expect(sing['foo'], equals('bar=qux'));
+    expect(doub['foo'], equals('bar=qux'));
   }
 
   void interpolate() {


### PR DESCRIPTION
Hi @mockturtl,

This PR fixes a bug that prevents the parser from correctly parsing values that contain equal signs (`=`). 

The problem is caused by performing a string split on every occurrence of the equal sign character, which causes the unintended side effect of also splitting the value of the variable.

### Example

A base64 encoded string will often end with an equal sign due to [padding](https://en.wikipedia.org/wiki/Padding_%28cryptography%29). For example, the string `"foo"` is encoded as `"Zm9vCg=="`, but incorrectly parsed by this library:

```dart
// FOO="Zm9vCg=="
print(dotenv.env['FOO']); // "Zm9vCg"
```

Note the missing `==` signs. The fix contained in this PR allows the correct parsing of the variable as `Zm9vCg==`.

Thanks, I hope you get a chance to review and merge this PR soon.