### PR TITLE
make DotEnv class based

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Release notes are available on [github][notes].
 [pub-semver-readme]: https://pub.dartlang.org/packages/pub_semver
 [notes]: https://github.com/mockturtl/dotenv/releases
 
+3.1.0
+-----
+
+- DotEnv is now class based
+- DotEnv does not load Platform.environment by default, use dotEnv instance for previous behavior. Existing methods `load` `clean` `isEveryDefined` and `env` work just like before. i.e no breaking change
+- Variables from env can be accessed directly using array accessor, dotEnv['API_KEY'] works just like dotEnv.env['API_KEY']
+- `dart pub global run dotenv -s` now allows skipping `Platform.environment` variables
+
 3.0.0
 -----
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ An _environment_ is the set of variables known to a process (say, `PATH`, `PORT`
 It is desirable to mimic the production environment during development (testing,
 staging, ...) by reading these values from a file.
 
-This library parses that file and merges its values with the built-in
+This library parses that file and optionally merges its values with the built-in
 [`Platform.environment`][docs-io] map.
 
 [docs-io]: https://api.dartlang.org/apidocs/channels/stable/dartdoc-viewer/dart:io.Platform#id_environment
@@ -57,7 +57,8 @@ Run:
 
 ```sh
 $ dart pub global run dotenv:new  # create a .env file and add it to .gitignore
-$ dart pub global run dotenv      # load the file and print the environment to stdout
+$ dart pub global run dotenv      # load the file and print all the environment variables to stdout
+$ dart pub global run dotenv -s     # load the file and print only the file environment variables to stdout
 ```
 
 #### discussion

--- a/bin/dotenv.dart
+++ b/bin/dotenv.dart
@@ -1,7 +1,7 @@
 import 'dart:io';
 
 import 'package:args/args.dart';
-import 'package:dotenv/dotenv.dart' as dotenv;
+import 'package:dotenv/dotenv.dart';
 
 final _argPsr = new ArgParser()
   ..addFlag('help', abbr: 'h', negatable: false, help: 'Print this help text.')
@@ -9,9 +9,14 @@ final _argPsr = new ArgParser()
       abbr: 'f',
       defaultsTo: '.env',
       help:
-          'File to read.\nProvides environment variable definitions, one per line.');
+          'File to read.\nProvides environment variable definitions, one per line.')
+  ..addFlag(
+    'skip-platform',
+    abbr: 's',
+    help: 'Skip Platform environment variables',
+  );
 
-/// Prints the [env] map.
+/// Prints the [dotEnv] map.
 ///
 /// ## usage
 ///
@@ -20,9 +25,18 @@ void main(List<String> argv) {
   var opts = _argPsr.parse(argv);
 
   if (opts['help'] == true) return _usage();
+  var file = opts['file'] as String;
+  if (opts.arguments.contains('-s')) {
+    _loadAndPrint(DotEnv(), file);
+    return;
+  }
 
-  dotenv.load(opts['file'] as String);
-  _p(dotenv.env);
+  _loadAndPrint(dotEnv, file);
+}
+
+void _loadAndPrint(DotEnv dotEnv, String file) {
+  dotEnv.load(file);
+  _p(dotEnv.env);
 }
 
 void _usage() {

--- a/lib/dotenv.dart
+++ b/lib/dotenv.dart
@@ -2,53 +2,25 @@
 ///
 /// ## usage
 ///
-/// Once you call [load], the top-level [env] map is available.
-/// You may wish to prefix the import.
+/// You can call [dotEnv.load()], to load the `.env` file
 ///
-///     import 'package:dotenv/dotenv.dart' show load, env;
+///     import 'package:dotenv/dotenv.dart';
 ///
 ///     void main() {
-///       load();
-///       var x = env['foo'];
+///       dotEnv.load();
+///       var x = dotEnv['foo'];
 ///       // ...
 ///     }
 ///
 /// Verify required variables are present:
 ///
 ///     const _requiredEnvVars = const ['host', 'port'];
-///     bool get hasEnv => isEveryDefined(_requiredEnvVars);
+///     bool get hasEnv => dotEnv.isEveryDefined(_requiredEnvVars);
+///
+/// `dotEnv` loads environment variables from `Platform.environment` as well.
+/// You can also create new instance of `DotEnv` to load variables without
+/// `Platform.environment` or to load from multiple sources.
 library dotenv;
 
-import 'dart:io';
-
-import 'package:meta/meta.dart';
-
-part 'src/parser.dart';
-
-var _env = new Map<String, String>.from(Platform.environment);
-
-/// A copy of [Platform.environment](dart:io) including variables loaded at runtime from a file.
-Map<String, String> get env => _env;
-
-/// Overwrite [env] with a new writable copy of [Platform.environment](dart:io).
-Map clean() => _env = new Map.from(Platform.environment);
-
-/// True if all supplied variables have nonempty value; false otherwise.
-/// Differs from [containsKey](dart:core) by excluding null values.
-/// Note [load] should be called first.
-bool isEveryDefined(Iterable<String> vars) =>
-    vars.every((k) => _env[k] != null && (_env[k]?.isNotEmpty ?? false));
-
-/// Read environment variables from [filename] and add them to [env].
-/// Logs to [stderr] if [filename] does not exist.
-void load([String filename = '.env', Parser psr = const Parser()]) {
-  var f = new File.fromUri(new Uri.file(filename));
-  var lines = _verify(f);
-  _env.addAll(psr.parse(lines));
-}
-
-List<String> _verify(File f) {
-  if (f.existsSync()) return f.readAsLinesSync();
-  stderr.writeln('[dotenv] Load failed: file not found: $f');
-  return [];
-}
+export 'package:dotenv/src/dotenv.dart';
+export 'package:dotenv/src/legacy.dart';

--- a/lib/src/dotenv.dart
+++ b/lib/src/dotenv.dart
@@ -1,0 +1,43 @@
+library dotenv;
+
+import 'dart:io';
+
+import 'package:meta/meta.dart';
+
+part 'parser.dart';
+
+class DotEnv {
+  var _env = Map<String, String>();
+
+  DotEnv();
+
+  String operator [](String index) => _env[index]!;
+
+  void addAll(Map<String, String> variableMap) => _env.addAll(variableMap);
+
+  /// Variables loaded at runtime from a file
+  Map<String, String> get env => _env;
+
+  /// Remove all variables from [env]
+  Map<String, String> clear() => _env..clear();
+
+  /// True if all supplied variables have nonempty value; false otherwise.
+  /// Differs from [containsKey](dart:core) by excluding null values.
+  /// Note [load] should be called first.
+  bool isEveryDefined(Iterable<String> vars) =>
+      vars.every((k) => (_env[k]?.isNotEmpty ?? false));
+
+  List<String> _verify(File f) {
+    if (f.existsSync()) return f.readAsLinesSync();
+    stderr.writeln('[dotenv] Load failed: file not found: $f');
+    return [];
+  }
+
+  /// Read environment variables from [filename] and add them to [env].
+  /// Logs to [stderr] if [filename] does not exist.
+  void load([String filename = '.env', Parser psr = const Parser()]) {
+    var f = new File.fromUri(new Uri.file(filename));
+    var lines = _verify(f);
+    _env.addAll(psr.parse(lines));
+  }
+}

--- a/lib/src/legacy.dart
+++ b/lib/src/legacy.dart
@@ -1,0 +1,27 @@
+import 'dart:io';
+import 'package:dotenv/src/dotenv.dart';
+
+final dotEnv = DotEnv()..env.addAll(Platform.environment);
+
+/// A copy of [Platform.environment](dart:io) including variables loaded at runtime from a file.
+@Deprecated("Use dotEnv directly or create a new instance of DotEnv")
+Map<String, String> get env => dotEnv.env;
+
+/// Overwrite [env] with a new writable copy of [Platform.environment](dart:io).
+@Deprecated("Use dotEnv directly or create a new instance of DotEnv")
+Map<String, String> clean() => (dotEnv
+  ..clear()
+  ..addAll(Platform.environment))
+    .env;
+
+/// True if all supplied variables have nonempty value; false otherwise.
+/// Differs from [containsKey](dart:core) by excluding null values.
+/// Note [load] should be called first.
+@Deprecated("Use dotEnv directly or create a new instance of DotEnv")
+final bool Function(Iterable<String>) isEveryDefined = dotEnv.isEveryDefined;
+
+/// Read environment variables from [filename] and add them to [env].
+/// Logs to [stderr] if [filename] does not exist.
+@Deprecated("Use dotEnv directly or create a new instance of DotEnv")
+void load([String filename = '.env', Parser psr = const Parser()]) =>
+    dotEnv.load(filename, psr);

--- a/test/dotenv_class_test.dart
+++ b/test/dotenv_class_test.dart
@@ -1,0 +1,52 @@
+import 'package:collection/collection.dart' show MapEquality;
+import 'package:dotenv/dotenv.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('[dotenv]', () {
+    var subj = DotenvTest();
+    setUp(() => subj.dotenv.env.addAll(vars));
+    tearDown(() => subj.dotenv.clear());
+
+    test('it can clean previously defined variables', subj.clean);
+    test('it is equal to empty map when clean', subj.clean2);
+    test('it confirms all required vars are defined', subj.every);
+    test('it fails when a required var is not defined', subj.every_fail);
+    test('it loads the file', subj.load, skip: 'pending');
+  });
+}
+
+const extra = const {'servlets': 'yes', 'rats': 'yes', 'horses': 'omgyes'};
+const vars = const {'x': '1', 'y': 'false', 'z': 'foo', 'empty': ''};
+
+class DotenvTest {
+  var dotenv = DotEnv();
+
+  void clean() {
+    dotenv.env.addAll(extra);
+    dotenv.clear();
+    extra.keys.forEach((k) => expect(dotenv.env.containsKey(k), isFalse));
+    vars.keys.forEach((k) => expect(dotenv.env.containsKey(k), isFalse));
+  }
+
+  void clean2() {
+    expect(_clean, isFalse);
+    dotenv.clear();
+    expect(_clean, isTrue);
+  }
+
+  void every() {
+    dotenv.env.addAll(extra);
+    expect(dotenv.isEveryDefined(['x', 'y', 'z']), isTrue);
+    expect(dotenv.isEveryDefined(['servlets', 'rats', 'horses']), isTrue);
+  }
+
+  void every_fail() {
+    expect(dotenv.isEveryDefined(['empty']), isFalse);
+    expect(dotenv.isEveryDefined(['no_such_key']), isFalse);
+  }
+
+  void load() {}
+
+  bool get _clean => const MapEquality().equals(dotenv.env, Map.identity());
+}


### PR DESCRIPTION
Made the following changes 

- `DotEnv` is now class based
- `DotEnv` does not load `Platform.environment` by default
- `dotEnv` instance loads `Platform.environment` by default
- Existing methods `load` `clean` `isEveryDefined` and `env` work just like before. i.e no breaking change
- Variables from env can be accessed directly using array accessor, `dotEnv['API_KEY']` works just like `dotEnv.env['API_KEY']`