### PR TITLE
add getOrElse to access environment values. 

### DIFF
--- a/lib/src/dotenv.dart
+++ b/lib/src/dotenv.dart
@@ -76,4 +76,12 @@ class DotEnv {
     }
     return f.readAsLinesSync();
   }
+
+  String getOrElse(String key, String Function() orElse) {
+    if (map.containsKey(key)) {
+      return _map[key]!;
+    } else {
+      return orElse();
+    }
+  }
 }

--- a/test/dotenv_test.dart
+++ b/test/dotenv_test.dart
@@ -65,6 +65,22 @@ void main() {
         expect(subj['some_test'], 'value');
       });
     });
+    group('getOrElse', () {
+      test('reads a value', () {
+        expect(
+          subj.getOrElse('x', () => throw Exception('Should get value of 1')),
+          '1',
+        );
+      });
+      test('calls orElse when value is not defined', () {
+        final got = subj.getOrElse('nope', () => 'value');
+        expect(got, 'value');
+        expect(
+          () => subj.getOrElse('nope', () => throw Exception()),
+          throwsA(isA<Exception>()),
+        );
+      });
+    });
   });
 }
 


### PR DESCRIPTION
- This aims to simplify reading values and throwing exceptions or provide a default if value isn't found
```dart
final port = subj.getOrElse('PORT', () => throw Exception('Port Variable is not defined'));
```

We can also do 
```dart
final port = subj.getOrElse('PORT', () =>'8080');
```

I'd love if this functionality is added to this package. Let me know what you think. 