### PR TITLE
feat: add silent option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project follows [pub-flavored semantic versioning][pub-semver]. ([more][pub
 [pub-semver]: https://www.dartlang.org/tools/pub/versioning.html#semantic-versions
 [pub-semver-readme]: https://pub.dartlang.org/packages/pub_semver
 
+## 4.2.0
+
+- [feat] add silent option
+
 ## 4.1.0
 
 - [feat] add `DotEnv.getOrElse`

--- a/lib/src/dotenv.dart
+++ b/lib/src/dotenv.dart
@@ -16,9 +16,13 @@ class DotEnv {
   /// Otherwise, it will be empty until populated by [load].
   final bool includePlatformEnvironment;
 
+  /// If true, when loading a list of env files, no message will be written to
+  /// [stderr] when a file cannot be found.
+  final bool silent;
+
   final _map = <String, String>{};
 
-  DotEnv({this.includePlatformEnvironment = false}) {
+  DotEnv({this.includePlatformEnvironment = false, this.silent = false}) {
     if (includePlatformEnvironment) _addPlatformEnvironment();
   }
 
@@ -78,7 +82,9 @@ class DotEnv {
 
   List<String> _verify(File f) {
     if (!f.existsSync()) {
-      stderr.writeln('[dotenv] Load failed: file not found: $f');
+      if (!silent) {
+        stderr.writeln('[dotenv] Load failed: file not found: $f');
+      }
       return [];
     }
     return f.readAsLinesSync();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dotenv
-version: 4.1.0
+version: 4.2.0
 
 description: Load environment variables from a `.env` file.
 homepage: https://github.com/mockturtl/dotenv


### PR DESCRIPTION
Hi there! Thanks for this package.

I'm currently in the process of writing a CLI tool and I have setup something like the following:
```dart
final env = DotEnv()..load([
  "$home/.config/{{APP_NAME}}/config",
  ".env",
]);
```

I want to look for the environment variables in a couple of different places, according to where the CLI tool is actually running on the system. Therefore, I don't want to let the user see any error messages that a file hasn't been found.

In my pull-request, I've added the `silent` option which suppresses this message. I look forward to hearing your feedback on this matter. @mockturtl 