### PR TITLE
v5 proposal

### DIFF
--- a/lib/dotenv.dart
+++ b/lib/dotenv.dart
@@ -1,17 +1,31 @@
-/// Loads environment variables from a `.env` file.
+/// Loads environment variables from a `.env` file and merges with
+/// `Platform.environment`.
 ///
-/// ## usage
+/// ## usages
 ///
-/// Call [DotEnv.load] to parse the file(s).
-/// Read variables from the underlying [Map] using the `[]` operator.
+/// Use the default instance of [DotEnv] to read env vars:
+///
+///    import 'package:dotenv/dotenv.dart';
+///
+///    void main() {
+///      final myVar = DotEnv.instance['MY_VAR'];
+///    }
+///
+/// Use `DotEnv(parser)..load()` to create a `DotEnv` instance
+/// with a custom parser:
 ///
 ///     import 'package:dotenv/dotenv.dart';
 ///
+///     class CustomParser implements Parser {
+///       Map<String, String> parse(Iterable<String> lines) {
+///         // custom implementation
+///       }
+///     }
+///
 ///     void main() {
-///       var env = DotEnv(includePlatformEnvironment: true)
-///         ..load('path/to/my/.env');
-///       var foo = env['foo'];
-///       var homeDir = env['HOME'];
+///       final env = DotEnv(CustomParser())..load();
+///       final foo = env['foo'];
+///       final homeDir = env['HOME'];
 ///       // ...
 ///     }
 ///
@@ -19,4 +33,4 @@
 ///
 ///     const _requiredEnvVars = ['host', 'port'];
 ///     bool get hasEnv => env.isEveryDefined(_requiredEnvVars);
-export 'package:dotenv/src/dotenv.dart';
+export 'package:dotenv/src/dotenv.dart' show DotEnv, Parser;

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -1,10 +1,13 @@
-import 'dart:io';
+part of './dotenv.dart';
 
-import 'package:meta/meta.dart';
+abstract class Parser {
+  /// Parses .env file contents into a [Map<String, String>].
+  Map<String, String> parse(Iterable<String> lines);
+}
 
 /// Creates key-value pairs from strings formatted as environment
 /// variable definitions.
-class Parser {
+class DefaultParser implements Parser {
   static const _singleQuot = "'";
   static const _keyword = 'export';
 
@@ -13,8 +16,8 @@ class Parser {
   static final _bashVar =
       new RegExp(r'(?:\\)?(\$)(?:{)?([a-zA-Z_][\w]*)+(?:})?');
 
-  /// [Parser] methods are pure functions.
-  const Parser();
+  /// [DefaultParser] methods are pure functions.
+  const DefaultParser();
 
   /// Substitutes $bash_vars in [val] with values from [env].
   @visibleForTesting


### PR DESCRIPTION
Hello @mockturtl 👋

This is a proposal PR which is by no means final, but a prototype for better understanding of the underlying problems and proposed solutions:

### Motivation

`dotenv` is used in many backend dart projects, and we've had a few support tickets raised at [globe.dev](https://globe.dev) regarding env vars loading.

#### `includeParentEnvironment`

I'm not sure why merging `.env` and `Platform.environment` is not a default behavior. Typically .env is used to override production env vars locally for development purposes. `.env` files are rarely checked in into version control system and cloud providers/hosting environments have their own secure way to define env vars. Bundling `.env` is less secure, since it's just a plain text inside a file inside an archive with the code. 

This PR implements merging `Platform.environment` with whatever is defined in `.env` as a default behaviour.

#### Initialization API

Compared to NodeJS's `require('dotenv').config()`, current initialization API is a bit more complicated, requires calling both constructor of `DotEnv` and `load()`, which has 2 parementers.

This PR implements singleton pattern on `DotEnv` class, similar to how it's done in [firebase/flutterfire](https://github.com/firebase/flutterfire). Reading env var becomes as easy as:

```dart
final myVar = DotEnv.instance['MY_VAR'];
```

Although I'm not sure when this could be useful, there's still a way to have a custom parser:

```dart
final dotenv = DotEnv(MyDotEnvParser())..load();
final myVar = dotenv['MY_VAR'];
```

---

Let me know what you think, if you're willing to accept these breaking changes, I'm happy to proceed with this PR, and update tests, docs, and readmes.